### PR TITLE
Exporting self-signed server certificate from JKS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /ssl/server/server-public.pem
 /ssl/server/server-private.pem
 /ssl/server/server-selfsigned.keystore
+/ssl/server/server-certificate.crt
 /data/
 /logs/
 /agent-templates/

--- a/scripts/check-configuration.sh
+++ b/scripts/check-configuration.sh
@@ -38,7 +38,7 @@ fi
 
 if [ ! -f "ssl/server/server-selfsigned.keystore" ]; then
     echo "INFO | ssl/server/server-selfsigned.keystore file not found, creating ..."
-    echo $PROJECT_ROOT
+    echo "$PROJECT_ROOT"
     ${SUDO_COMMAND} docker run --rm -v "${PROJECT_ROOT}/ssl/server:/tmp" -v "${PROJECT_ROOT}/ssl/server:/tmp/hsperfdata_root" -w /tmp --user "$UID:$UID" openjdk:21-jdk-slim-bookworm \
       keytool -genkey -alias selfsigned \
       -keyalg RSA \
@@ -48,6 +48,11 @@ if [ ! -f "ssl/server/server-selfsigned.keystore" ]; then
       -dname "CN=localhost, OU=Tuoni, O=ShellDot, L=Tallinn, C=Estonia" \
       -keypass selfsigned -storepass \
       selfsigned
+    ${SUDO_COMMAND} docker run --rm -v "${PROJECT_ROOT}/ssl/server:/tmp" -v "${PROJECT_ROOT}/ssl/server:/tmp/hsperfdata_root" -w /tmp --user "$UID:$UID" openjdk:21-jdk-slim-bookworm \
+      keytool -exportcert -alias selfsigned \
+      -keystore server-selfsigned.keystore \
+      -file /tmp/server-certificate.crt \
+      -rfc -storepass selfsigned
     ${SUDO_COMMAND} rmdir "${PROJECT_ROOT}/ssl/server/hsperfdata_root"
 fi
 


### PR DESCRIPTION
This PR will export the self-signed server certificate from Java keystore during initial certificate creation. Thus making it easier to trust by the OS.