### PR TITLE
Add gawk as required packages

### DIFF
--- a/scripts/check-packages.sh
+++ b/scripts/check-packages.sh
@@ -15,6 +15,7 @@ if ! command_exists "curl"; then REQUIRED_PACKAGES+=('curl'); fi
 if ! command_exists "jq"; then REQUIRED_PACKAGES+=('jq'); fi
 if ! command_exists "git"; then REQUIRED_PACKAGES+=('git'); fi
 if ! command_exists "rsync"; then REQUIRED_PACKAGES+=('rsync'); fi
+if ! command_exists "gawk"; then REQUIRED_PACKAGES+=('gawk'); fi
 
 # Install other missing packages
 if [ "${#REQUIRED_PACKAGES[@]}" -ne 0 ]; then


### PR DESCRIPTION
Ubuntu doesn't have GNU awk installed by default which is required for the -i option used on line 133 in check-configuration.sh, adding gawk as a pachage will solve this. 

Line 133 - check-configuration.sh
awk -i inplace -v port="$TUONI_CLIENT_PORT" 