### PR TITLE
0.8.1

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,1 +1,1 @@
-version: 0.8.0
+version: 0.8.1


### PR DESCRIPTION
## 🔌 Server

* Added backwards compatibility support for older payload plugins. It is now possible use payload plugins compiled for 0.7.x with 0.8.1 server. 