### PR TITLE
Prepare server-side scripting pip support for upcoming Tuoni release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     image: ghcr.io/shell-dot/tuoni/server:${VERSION}
     volumes:
       - ./data/:/app/data/
+      - ./python-site-packages:/app/venv/external-packages/:rw
       - ./logs/server/:/app/logs/
       - ./payload-templates/:/app/custom-payload-templates/:ro
       - ./config/tuoni.yml:/app/tuoni-production.yml:ro

--- a/scripts/check-configuration.sh
+++ b/scripts/check-configuration.sh
@@ -70,7 +70,7 @@ if [[ ! $($PROJECT_ROOT/scripts/tools/yq '.client.port' $TUONI_CONFIG_FILE_PATH)
 fi
 
 # Ensure necessary directories exist
-for dir in data logs/server logs/client logs/nginx payload-templates plugins transfer; do
+for dir in data logs/server logs/client logs/nginx payload-templates plugins transfer python-site-packages; do
   if [ ! -d "$PROJECT_ROOT/$dir" ]; then
     echo "INFO | $dir directory not found, creating ..."
     mkdir -p "$PROJECT_ROOT/$dir"

--- a/scripts/tuoni-command-list.sh
+++ b/scripts/tuoni-command-list.sh
@@ -23,7 +23,8 @@ tuoni_commands_array=(
     "import-tuoni-package" \
     "client" \
     "server" \
-    "docs"
+    "docs" \
+    "pip"
 )
 
 tuoni_client_commands_array=("start" "stop" "restart" "logs")

--- a/scripts/tuoni-command.sh
+++ b/scripts/tuoni-command.sh
@@ -14,10 +14,12 @@ export TUONI_CLIENT_LOGGER_LEVEL=$($PROJECT_ROOT/scripts/tools/yq '.client.logge
 export TUONI_CLIENT_LOGGER_HEADERS=$($PROJECT_ROOT/scripts/tools/yq -o=json '.client.logger.headers' $TUONI_CONFIG_FILE_PATH | jq -c)
 
 export TUONI_DOCKER_COMPOSE_COMMAND="docker compose --env-file ${PROJECT_ROOT}/config/tuoni.env -f ${PROJECT_ROOT}/docker-compose.yml"
+export TUONI_DOCKER_PIP_COMMAND="docker run --env-file ${PROJECT_ROOT}/config/tuoni.env --rm -v ${PROJECT_ROOT}/python-site-packages:/app/venv/external-packages --user $UID:$UID --entrypoint /app/venv/bin/pip ghcr.io/shell-dot/tuoni/server:${VERSION} --no-cache-dir ${TUONI_SUBCOMMAND_WITH_ARGS}"
 
 TUONI_COMPONENT=$(basename "$0")
 TUONI_COMMAND="$1"
 TUONI_SUBCOMMAND="$2"
+TUONI_SUBCOMMAND_WITH_ARGS="${*:2}"
 
 if [ "$TUONI_COMPONENT" == "tuoni" ]; then
   TUONI_COMPONENT="app"
@@ -133,6 +135,7 @@ $(tput smul)AVAILABLE COMMANDS:$(tput rmul)
     $(tput setaf 3)transfer-tuoni-package$(tput sgr0) Rsync transfer folder to remote defined in config/tuoni.env.
     $(tput setaf 3)export-tuoni-package$(tput sgr0)   Export current git repository and docker images to transfer folder.
     $(tput setaf 3)import-tuoni-package$(tput sgr0)   Import git repository and docker images from transfer folder.
+    $(tput setaf 3)pip$(tput sgr0)                    Manage Python packages for Tuoni Server-Side Scripting.
 
 $(tput smul)ADDITIONAL INFORMATION:$(tput rmul)
     Tuoni URL:           $(tput setaf 4)https://${TUONI_HOST_FQDN}:${TUONI_CLIENT_PORT}/$(tput sgr0)
@@ -306,6 +309,11 @@ fi
 if [ "$TUONI_COMMAND" == "docs" ]; then
   handle_docs_command "$TUONI_SUBCOMMAND"
 fi
+
+if [ "$TUONI_COMMAND" == "pip" ]; then
+  ${TUONI_SUDO_COMMAND} ${TUONI_DOCKER_PIP_COMMAND} ${TUONI_SUBCOMMAND_WITH_ARGS}
+fi
+
 
 # Display Tuoni URL, username, and password during setup
 if [ -n "${TUONI_USERNAME_TO_CONFIG}" ]; then

--- a/tuoni
+++ b/tuoni
@@ -13,4 +13,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 . $PROJECT_ROOT/config/tuoni.env
 
 ### full app
-. $PROJECT_ROOT/scripts/tuoni-command.sh $1 $2
+. $PROJECT_ROOT/scripts/tuoni-command.sh $*


### PR DESCRIPTION
Add support for installing third-party python packages with the following command:
`./tuoni pip install <package_name>`